### PR TITLE
Send memory usage information together with metrics on Linux

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   release:
     name: "Release"
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   commits:
     name: "Commits"
-    if: ${{ github.event_name == 'pull_request' }}
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,11 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2
@@ -136,7 +139,7 @@ jobs:
           pytest --verbose --cov=. --cov-report=xml .
 
       - name: "Upload coverage"
-        if: matrix.python-version == '3.7'
+        if: matrix.python-version == '3.7' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b  # v2.1.0
         with:
           files: coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Send current system memory usage and total available memory together with metrics on Linux systems.
+
 ## [1.3.0] - 2022-02-02
 
 ### Added

--- a/tests/django/test_django.py
+++ b/tests/django/test_django.py
@@ -38,6 +38,7 @@ def test_middleware_should_call_apilytics_api(
         "requestSize",
         "responseSize",
         "timeMillis",
+        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
     }
     assert data["path"] == "/"
     assert data["method"] == "GET"
@@ -45,6 +46,9 @@ def test_middleware_should_call_apilytics_api(
     assert data["requestSize"] == 0
     assert data["responseSize"] > 0
     assert isinstance(data["timeMillis"], int)
+    if platform.system() == "Linux":
+        assert isinstance(data["memoryUsage"], int)
+        assert isinstance(data["memoryTotal"], int)
 
 
 def test_middleware_should_send_query_params(
@@ -123,12 +127,16 @@ def test_middleware_should_work_with_streaming_response(
         "statusCode",
         "requestSize",
         "timeMillis",
+        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
     }
     assert data["path"] == "/streaming"
     assert data["method"] == "GET"
     assert data["statusCode"] == 200
     assert data["requestSize"] == 0
     assert isinstance(data["timeMillis"], int)
+    if platform.system() == "Linux":
+        assert isinstance(data["memoryUsage"], int)
+        assert isinstance(data["memoryTotal"], int)
 
 
 @django.test.override_settings(APILYTICS_API_KEY=None)
@@ -160,6 +168,7 @@ def test_middleware_should_send_data_even_on_errors(
         "statusCode",
         "requestSize",
         "responseSize",
+        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
     }
     assert data["method"] == "GET"
     assert data["path"] == "/error"
@@ -167,3 +176,6 @@ def test_middleware_should_send_data_even_on_errors(
     assert data["requestSize"] == 0
     assert data["responseSize"] > 0
     assert isinstance(data["timeMillis"], int)
+    if platform.system() == "Linux":
+        assert isinstance(data["memoryUsage"], int)
+        assert isinstance(data["memoryTotal"], int)

--- a/tests/fastapi/test_fastapi.py
+++ b/tests/fastapi/test_fastapi.py
@@ -44,6 +44,7 @@ def test_middleware_should_call_apilytics_api(
         "responseSize",
         "userAgent",
         "timeMillis",
+        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
     }
     assert data["path"] == "/"
     assert data["method"] == "GET"
@@ -52,6 +53,9 @@ def test_middleware_should_call_apilytics_api(
     assert data["responseSize"] > 0
     assert data["userAgent"] == "testclient"
     assert isinstance(data["timeMillis"], int)
+    if platform.system() == "Linux":
+        assert isinstance(data["memoryUsage"], int)
+        assert isinstance(data["memoryTotal"], int)
 
 
 def test_middleware_should_send_query_params(
@@ -128,6 +132,7 @@ def test_middleware_should_work_with_streaming_response(
         "requestSize",
         "userAgent",
         "timeMillis",
+        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
     }
     assert data["path"] == "/streaming"
     assert data["method"] == "GET"
@@ -135,6 +140,9 @@ def test_middleware_should_work_with_streaming_response(
     assert data["requestSize"] == 0
     assert data["userAgent"] == "testclient"
     assert isinstance(data["timeMillis"], int)
+    if platform.system() == "Linux":
+        assert isinstance(data["memoryUsage"], int)
+        assert isinstance(data["memoryTotal"], int)
 
 
 @tests.fastapi.conftest.override_middleware(
@@ -166,9 +174,19 @@ def test_middleware_should_send_data_even_on_errors(
 
     __, call_kwargs = mocked_urlopen.call_args
     data = tests.conftest.decode_request_data(call_kwargs["data"])
-    assert data.keys() == {"method", "path", "timeMillis", "userAgent", "requestSize"}
+    assert data.keys() == {
+        "method",
+        "path",
+        "timeMillis",
+        "userAgent",
+        "requestSize",
+        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+    }
     assert data["method"] == "GET"
     assert data["path"] == "/error"
     assert data["requestSize"] == 0
     assert data["userAgent"] == "testclient"
     assert isinstance(data["timeMillis"], int)
+    if platform.system() == "Linux":
+        assert isinstance(data["memoryUsage"], int)
+        assert isinstance(data["memoryTotal"], int)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 import platform
+import textwrap
 import unittest.mock
 import urllib.error
 
@@ -34,11 +35,20 @@ def test_apilytics_sender_should_call_apilytics_api(
     }
 
     data = tests.conftest.decode_request_data(call_kwargs["data"])
-    assert data.keys() == {"path", "method", "statusCode", "timeMillis"}
+    assert data.keys() == {
+        "path",
+        "method",
+        "statusCode",
+        "timeMillis",
+        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+    }
     assert data["path"] == "/"
     assert data["method"] == "GET"
     assert data["statusCode"] == 200
     assert isinstance(data["timeMillis"], int)
+    if platform.system() == "Linux":
+        assert data["memoryUsage"] > 0
+        assert data["memoryTotal"] > data["memoryUsage"]
 
 
 def test_apilytics_sender_should_send_query_params(
@@ -107,10 +117,142 @@ def test_apilytics_sender_should_handle_empty_values_correctly(
     assert mocked_urlopen.call_count == 1
     __, call_kwargs = mocked_urlopen.call_args
     data = tests.conftest.decode_request_data(call_kwargs["data"])
-    assert data.keys() == {"path", "method", "timeMillis"}
+    assert data.keys() == {
+        "path",
+        "method",
+        "timeMillis",
+        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+    }
     assert data["path"] == ""
     assert data["method"] == ""
     assert isinstance(data["timeMillis"], int)
+    if platform.system() == "Linux":
+        assert isinstance(data["memoryUsage"], int)
+        assert isinstance(data["memoryTotal"], int)
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+def test_apilytics_sender_should_read_proc_meminfo_on_linux(
+    _mocked_system: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    memory_total = 4_125_478_912
+    memory_available = 3_360_526_336
+
+    mocked_meminfo = textwrap.dedent(
+        f"""\
+        MemTotal:        {memory_total // 1024} kB
+        MemFree:          789940 kB
+        MemAvailable:    {memory_available // 1024} kB
+        Buffers:         2450168 kB
+        """  # The real file is longer.
+    )
+    with unittest.mock.patch(
+        "builtins.open", new=unittest.mock.mock_open(read_data=mocked_meminfo)
+    ) as mocked_open:
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 1
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert data["memoryUsage"] == memory_total - memory_available
+    assert data["memoryTotal"] == memory_total
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+def test_apilytics_sender_should_handle_proc_meminfo_read_failure(
+    _mocked_system: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    with unittest.mock.patch("builtins.open", side_effect=OSError) as mocked_open:
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 1
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert "memoryUsage" not in data
+    assert "memoryTotal" not in data
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+def test_apilytics_sender_should_handle_proc_meminfo_total_missing(
+    _mocked_system: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    with unittest.mock.patch(
+        "builtins.open", new=unittest.mock.mock_open(read_data="")
+    ) as mocked_open:
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 1
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert "memoryUsage" not in data
+    assert "memoryTotal" not in data
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+def test_apilytics_sender_should_handle_proc_meminfo_available_missing(
+    _mocked_system: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    memory_total = 1048576
+    with unittest.mock.patch(
+        "builtins.open",
+        new=unittest.mock.mock_open(read_data=f"MemTotal: {memory_total // 1024}"),
+    ) as mocked_open:
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 1
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert "memoryUsage" not in data
+    assert data["memoryTotal"] == memory_total
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Windows")
+def test_apilytics_sender_should_not_read_proc_meminfo_when_not_on_linux(
+    _mocked_system: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    with unittest.mock.patch("builtins.open") as mocked_open:
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 0
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert "memoryUsage" not in data
+    assert "memoryTotal" not in data
 
 
 @unittest.mock.patch(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,7 +41,7 @@ def test_apilytics_sender_should_call_apilytics_api(
     assert isinstance(data["timeMillis"], int)
 
 
-def test_middleware_should_send_query_params(
+def test_apilytics_sender_should_send_query_params(
     mocked_urlopen: unittest.mock.MagicMock,
 ) -> None:
     with apilytics.core.ApilyticsSender(
@@ -59,7 +59,7 @@ def test_middleware_should_send_query_params(
     assert data["query"] == "key=value?other=123"
 
 
-def test_middleware_should_not_send_empty_query_params(
+def test_apilytics_sender_should_not_send_empty_query_params(
     mocked_urlopen: unittest.mock.MagicMock,
 ) -> None:
     with apilytics.core.ApilyticsSender(


### PR DESCRIPTION
We handle only Linux since getting accurate memory usage values on it is
most important. Memory cannot be read platform independently in Python
and we don't want at this point to include any external dependencies,
such as [`psutil`](https://pypi.org/project/psutil/). We might want to add support for other systems when
the need arises for some user, it likely won't happen soon since since
production web servers are not often ran on non-Linux systems.

Good to note that `MemAvailable` in `/proc/meminfo` is only available on
Linux kernel 3.14 and up, but since 3.14 has already reached end of
life we can pretty safely ignore support for systems before it.