### PR TITLE
Add platform name to sent Apilytics version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Send current system memory usage and total available memory together with metrics on Linux systems.
+- Add platform name to sent Apilytics version info.
 
 ## [1.3.0] - 2022-02-02
 

--- a/apilytics/core.py
+++ b/apilytics/core.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import json
 import platform
 import re
+import sys
 import time
 import types
 import urllib.error
@@ -44,7 +45,7 @@ class ApilyticsSender:
 
     _apilytics_version_template: ClassVar[
         str
-    ] = f"{{integration}}/{apilytics.__version__};python/{platform.python_version()}"
+    ] = f"{{integration}}/{apilytics.__version__};python/{platform.python_version()};{{library}};{sys.platform}"
 
     def __init__(
         self,
@@ -85,10 +86,9 @@ class ApilyticsSender:
         self._status_code: Optional[int] = None
 
         self._apilytics_version = self._apilytics_version_template.format(
-            integration=apilytics_integration or "apilytics-python-core"
+            integration=apilytics_integration or "apilytics-python-core",
+            library=integrated_library or "",
         )
-        if integrated_library:
-            self._apilytics_version += f";{integrated_library}"
 
     def __enter__(self) -> "ApilyticsSender":
         """Start the timer, measuring how long the ``with`` block takes to execute."""

--- a/tests/django/test_django.py
+++ b/tests/django/test_django.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 import unittest.mock
 
 import django.test
@@ -27,7 +28,7 @@ def test_middleware_should_call_apilytics_api(
         # urllib calls `capitalize()` on the header keys.
         "Content-type": "application/json",
         "X-api-key": "dummy-key",
-        "Apilytics-version": f"apilytics-python-django/{apilytics.__version__};python/{platform.python_version()};django/{django.__version__}",
+        "Apilytics-version": f"apilytics-python-django/{apilytics.__version__};python/{platform.python_version()};django/{django.__version__};{sys.platform}",
     }
 
     data = tests.conftest.decode_request_data(call_kwargs["data"])

--- a/tests/fastapi/test_fastapi.py
+++ b/tests/fastapi/test_fastapi.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 import unittest.mock
 
 import fastapi.middleware
@@ -32,7 +33,7 @@ def test_middleware_should_call_apilytics_api(
         # urllib calls `capitalize()` on the header keys.
         "Content-type": "application/json",
         "X-api-key": "dummy-key",
-        "Apilytics-version": f"apilytics-python-fastapi/{apilytics.__version__};python/{platform.python_version()};fastapi/{fastapi.__version__}",
+        "Apilytics-version": f"apilytics-python-fastapi/{apilytics.__version__};python/{platform.python_version()};fastapi/{fastapi.__version__};{sys.platform}",
     }
 
     data = tests.conftest.decode_request_data(call_kwargs["data"])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 import textwrap
 import unittest.mock
 import urllib.error
@@ -31,7 +32,7 @@ def test_apilytics_sender_should_call_apilytics_api(
         # urllib calls `capitalize()` on the header keys.
         "Content-type": "application/json",
         "X-api-key": "dummy-key",
-        "Apilytics-version": f"apilytics-python-core/{apilytics.__version__};python/{platform.python_version()}",
+        "Apilytics-version": f"apilytics-python-core/{apilytics.__version__};python/{platform.python_version()};;{sys.platform}",
     }
 
     data = tests.conftest.decode_request_data(call_kwargs["data"])


### PR DESCRIPTION
Use `sys.platform` for this (instead of `platform.system()`) since it's
more consistent with Node.js's `process.platform` values.

Atm rebased on top of #14, it should be merged first.