### PR TITLE
Send current system CPU usage together with metrics on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Send current system CPU usage together with metrics on Linux systems.
 - Send current system memory usage and total available memory together with metrics on Linux systems.
 - Add platform name to sent Apilytics version info.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,3 +35,9 @@ def mocked_executor() -> Generator[None, None, None]:
         new=_MockedExecutor,
     ):
         yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mocked_sleep() -> Generator[None, None, None]:
+    with unittest.mock.patch("apilytics.core.time.sleep", new=lambda secs: None):
+        yield

--- a/tests/django/test_django.py
+++ b/tests/django/test_django.py
@@ -39,7 +39,11 @@ def test_middleware_should_call_apilytics_api(
         "requestSize",
         "responseSize",
         "timeMillis",
-        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+        *(
+            ("cpuUsage", "memoryUsage", "memoryTotal")
+            if platform.system() == "Linux"
+            else ()
+        ),
     }
     assert data["path"] == "/"
     assert data["method"] == "GET"
@@ -48,6 +52,7 @@ def test_middleware_should_call_apilytics_api(
     assert data["responseSize"] > 0
     assert isinstance(data["timeMillis"], int)
     if platform.system() == "Linux":
+        assert isinstance(data["cpuUsage"], float)
         assert isinstance(data["memoryUsage"], int)
         assert isinstance(data["memoryTotal"], int)
 
@@ -128,7 +133,11 @@ def test_middleware_should_work_with_streaming_response(
         "statusCode",
         "requestSize",
         "timeMillis",
-        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+        *(
+            ("cpuUsage", "memoryUsage", "memoryTotal")
+            if platform.system() == "Linux"
+            else ()
+        ),
     }
     assert data["path"] == "/streaming"
     assert data["method"] == "GET"
@@ -136,6 +145,7 @@ def test_middleware_should_work_with_streaming_response(
     assert data["requestSize"] == 0
     assert isinstance(data["timeMillis"], int)
     if platform.system() == "Linux":
+        assert isinstance(data["cpuUsage"], float)
         assert isinstance(data["memoryUsage"], int)
         assert isinstance(data["memoryTotal"], int)
 
@@ -169,7 +179,11 @@ def test_middleware_should_send_data_even_on_errors(
         "statusCode",
         "requestSize",
         "responseSize",
-        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+        *(
+            ("cpuUsage", "memoryUsage", "memoryTotal")
+            if platform.system() == "Linux"
+            else ()
+        ),
     }
     assert data["method"] == "GET"
     assert data["path"] == "/error"
@@ -178,5 +192,6 @@ def test_middleware_should_send_data_even_on_errors(
     assert data["responseSize"] > 0
     assert isinstance(data["timeMillis"], int)
     if platform.system() == "Linux":
+        assert isinstance(data["cpuUsage"], float)
         assert isinstance(data["memoryUsage"], int)
         assert isinstance(data["memoryTotal"], int)

--- a/tests/fastapi/test_fastapi.py
+++ b/tests/fastapi/test_fastapi.py
@@ -45,7 +45,11 @@ def test_middleware_should_call_apilytics_api(
         "responseSize",
         "userAgent",
         "timeMillis",
-        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+        *(
+            ("cpuUsage", "memoryUsage", "memoryTotal")
+            if platform.system() == "Linux"
+            else ()
+        ),
     }
     assert data["path"] == "/"
     assert data["method"] == "GET"
@@ -55,6 +59,7 @@ def test_middleware_should_call_apilytics_api(
     assert data["userAgent"] == "testclient"
     assert isinstance(data["timeMillis"], int)
     if platform.system() == "Linux":
+        assert isinstance(data["cpuUsage"], float)
         assert isinstance(data["memoryUsage"], int)
         assert isinstance(data["memoryTotal"], int)
 
@@ -133,7 +138,11 @@ def test_middleware_should_work_with_streaming_response(
         "requestSize",
         "userAgent",
         "timeMillis",
-        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+        *(
+            ("cpuUsage", "memoryUsage", "memoryTotal")
+            if platform.system() == "Linux"
+            else ()
+        ),
     }
     assert data["path"] == "/streaming"
     assert data["method"] == "GET"
@@ -142,6 +151,7 @@ def test_middleware_should_work_with_streaming_response(
     assert data["userAgent"] == "testclient"
     assert isinstance(data["timeMillis"], int)
     if platform.system() == "Linux":
+        assert isinstance(data["cpuUsage"], float)
         assert isinstance(data["memoryUsage"], int)
         assert isinstance(data["memoryTotal"], int)
 
@@ -181,7 +191,11 @@ def test_middleware_should_send_data_even_on_errors(
         "timeMillis",
         "userAgent",
         "requestSize",
-        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+        *(
+            ("cpuUsage", "memoryUsage", "memoryTotal")
+            if platform.system() == "Linux"
+            else ()
+        ),
     }
     assert data["method"] == "GET"
     assert data["path"] == "/error"
@@ -189,5 +203,6 @@ def test_middleware_should_send_data_even_on_errors(
     assert data["userAgent"] == "testclient"
     assert isinstance(data["timeMillis"], int)
     if platform.system() == "Linux":
+        assert isinstance(data["cpuUsage"], float)
         assert isinstance(data["memoryUsage"], int)
         assert isinstance(data["memoryTotal"], int)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 import platform
 import sys
 import textwrap
+import time
 import unittest.mock
 import urllib.error
 
@@ -8,6 +9,8 @@ import apilytics.core
 import tests.conftest
 
 
+# Restore the real sleep behavior for this one test for thoroughness.
+@unittest.mock.patch("apilytics.core.time.sleep", new=time.sleep)
 def test_apilytics_sender_should_call_apilytics_api(
     mocked_urlopen: unittest.mock.MagicMock,
 ) -> None:
@@ -41,13 +44,18 @@ def test_apilytics_sender_should_call_apilytics_api(
         "method",
         "statusCode",
         "timeMillis",
-        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+        *(
+            ("cpuUsage", "memoryUsage", "memoryTotal")
+            if platform.system() == "Linux"
+            else ()
+        ),
     }
     assert data["path"] == "/"
     assert data["method"] == "GET"
     assert data["statusCode"] == 200
     assert isinstance(data["timeMillis"], int)
     if platform.system() == "Linux":
+        assert 0 <= data["cpuUsage"] <= 1
         assert data["memoryUsage"] > 0
         assert data["memoryTotal"] > data["memoryUsage"]
 
@@ -122,19 +130,186 @@ def test_apilytics_sender_should_handle_empty_values_correctly(
         "path",
         "method",
         "timeMillis",
-        *(("memoryUsage", "memoryTotal") if platform.system() == "Linux" else ()),
+        *(
+            ("cpuUsage", "memoryUsage", "memoryTotal")
+            if platform.system() == "Linux"
+            else ()
+        ),
     }
     assert data["path"] == ""
     assert data["method"] == ""
     assert isinstance(data["timeMillis"], int)
     if platform.system() == "Linux":
+        assert isinstance(data["cpuUsage"], float)
         assert isinstance(data["memoryUsage"], int)
         assert isinstance(data["memoryTotal"], int)
 
 
 @unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+@unittest.mock.patch("apilytics.core._get_used_and_total_memory", return_value=(0, 0))
+def test_apilytics_sender_should_read_proc_stat_on_linux(
+    _mocked_system: unittest.mock.MagicMock,
+    _mocked_memory: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    mocked_stat_start = textwrap.dedent(
+        """\
+        cpu  27133 0 33621 13668027 1459 0 508 10 100 100
+        cpu0 7260 0 7391 3420134 484 0 80 0 0 0
+        cpu1 7346 0 9306 3412338 138 0 82 0 0 0
+        """  # The real file is longer.
+    )
+    mocked_stat_end = textwrap.dedent(
+        """\
+        cpu  28869 0 33657 13680890 1460 0 508 20 200 200
+        cpu0 7263 0 7398 3423775 484 0 80 0 0 0
+        cpu1 9069 0 9314 3414266 138 0 82 0 0 0
+        """
+    )
+    with unittest.mock.patch(
+        "builtins.open",
+        new=unittest.mock.mock_open(read_data=mocked_stat_start),
+    ) as mocked_open:
+        mocked_open.side_effect = (
+            mocked_open.return_value,
+            unittest.mock.mock_open(read_data=mocked_stat_end).return_value,
+        )
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 2
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    # Totals ignore last two "guest" fields.
+    total_start = 27133 + 0 + 33621 + 13668027 + 1459 + 0 + 508 + 10
+    total_end = 28869 + 0 + 33657 + 13680890 + 1460 + 0 + 508 + 20
+    # Idles combine idle and iowait.
+    idle_start = 13668027 + 1459
+    idle_end = 13680890 + 1460
+    assert data["cpuUsage"] == 1 - (idle_end - idle_start) / (total_end - total_start)
+    assert data["cpuUsage"] == 0.12167144612863579
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+@unittest.mock.patch("apilytics.core._get_used_and_total_memory", return_value=(0, 0))
+def test_apilytics_sender_should_handle_proc_stat_read_failure(
+    _mocked_system: unittest.mock.MagicMock,
+    _mocked_memory: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    with unittest.mock.patch("builtins.open", side_effect=OSError) as mocked_open:
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 1
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert "cpuUsage" not in data
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+@unittest.mock.patch("apilytics.core._get_used_and_total_memory", return_value=(0, 0))
+def test_apilytics_sender_should_handle_proc_stat_iowait_missing(
+    _mocked_system: unittest.mock.MagicMock,
+    _mocked_memory: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    mocked_stat_start = "cpu  27133 0 33621 13668027"
+    mocked_stat_end = "cpu  28869 0 33657 13680890"
+    with unittest.mock.patch(
+        "builtins.open",
+        new=unittest.mock.mock_open(read_data=mocked_stat_start),
+    ) as mocked_open:
+        mocked_open.side_effect = (
+            mocked_open.return_value,
+            unittest.mock.mock_open(read_data=mocked_stat_end).return_value,
+        )
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 2
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    total_start = 27133 + 0 + 33621 + 13668027
+    total_end = 28869 + 0 + 33657 + 13680890
+    idle_start = 13668027
+    idle_end = 13680890
+    assert data["cpuUsage"] == 1 - (idle_end - idle_start) / (total_end - total_start)
+    assert data["cpuUsage"] == 0.12107960368978476
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+@unittest.mock.patch("apilytics.core._get_used_and_total_memory", return_value=(0, 0))
+def test_apilytics_sender_should_handle_proc_stat_timers_not_increased_zero_division(
+    _mocked_system: unittest.mock.MagicMock,
+    _mocked_memory: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    mocked_stat = "cpu  27133 0 33621 13668027"
+    with unittest.mock.patch(
+        "builtins.open",
+        new=unittest.mock.mock_open(read_data=mocked_stat),
+    ) as mocked_open:
+        mocked_open.side_effect = (
+            mocked_open.return_value,
+            unittest.mock.mock_open(read_data=mocked_stat).return_value,
+        )
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 2
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert data["cpuUsage"] == 0.0
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Windows")
+@unittest.mock.patch("apilytics.core._get_used_and_total_memory", return_value=(0, 0))
+def test_apilytics_sender_should_not_read_proc_stat_when_not_on_linux(
+    _mocked_system: unittest.mock.MagicMock,
+    _mocked_memory: unittest.mock.MagicMock,
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    with unittest.mock.patch("builtins.open") as mocked_open:
+        with apilytics.core.ApilyticsSender(
+            api_key="dummy-key",
+            path="/",
+            method="GET",
+        ) as sender:
+            sender.set_response_info(status_code=200)
+
+    assert mocked_open.call_count == 0
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert "cpuUsage" not in data
+
+
+@unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+@unittest.mock.patch("apilytics.core._get_cpu_usage", return_value=0.0)
 def test_apilytics_sender_should_read_proc_meminfo_on_linux(
     _mocked_system: unittest.mock.MagicMock,
+    _mocked_cpu_usage: unittest.mock.MagicMock,
     mocked_urlopen: unittest.mock.MagicMock,
 ) -> None:
     memory_total = 4_125_478_912
@@ -167,8 +342,10 @@ def test_apilytics_sender_should_read_proc_meminfo_on_linux(
 
 
 @unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+@unittest.mock.patch("apilytics.core._get_cpu_usage", return_value=0.0)
 def test_apilytics_sender_should_handle_proc_meminfo_read_failure(
     _mocked_system: unittest.mock.MagicMock,
+    _mocked_cpu_usage: unittest.mock.MagicMock,
     mocked_urlopen: unittest.mock.MagicMock,
 ) -> None:
     with unittest.mock.patch("builtins.open", side_effect=OSError) as mocked_open:
@@ -188,8 +365,10 @@ def test_apilytics_sender_should_handle_proc_meminfo_read_failure(
 
 
 @unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+@unittest.mock.patch("apilytics.core._get_cpu_usage", return_value=0.0)
 def test_apilytics_sender_should_handle_proc_meminfo_total_missing(
     _mocked_system: unittest.mock.MagicMock,
+    _mocked_cpu_usage: unittest.mock.MagicMock,
     mocked_urlopen: unittest.mock.MagicMock,
 ) -> None:
     with unittest.mock.patch(
@@ -211,8 +390,10 @@ def test_apilytics_sender_should_handle_proc_meminfo_total_missing(
 
 
 @unittest.mock.patch("apilytics.core.platform.system", return_value="Linux")
+@unittest.mock.patch("apilytics.core._get_cpu_usage", return_value=0.0)
 def test_apilytics_sender_should_handle_proc_meminfo_available_missing(
     _mocked_system: unittest.mock.MagicMock,
+    _mocked_cpu_usage: unittest.mock.MagicMock,
     mocked_urlopen: unittest.mock.MagicMock,
 ) -> None:
     memory_total = 1048576
@@ -236,8 +417,10 @@ def test_apilytics_sender_should_handle_proc_meminfo_available_missing(
 
 
 @unittest.mock.patch("apilytics.core.platform.system", return_value="Windows")
+@unittest.mock.patch("apilytics.core._get_cpu_usage", return_value=0.0)
 def test_apilytics_sender_should_not_read_proc_meminfo_when_not_on_linux(
     _mocked_system: unittest.mock.MagicMock,
+    _mocked_cpu_usage: unittest.mock.MagicMock,
     mocked_urlopen: unittest.mock.MagicMock,
 ) -> None:
     with unittest.mock.patch("builtins.open") as mocked_open:


### PR DESCRIPTION
Similar reasoning for only handling Linux for now as in 2e36b87.

Atm rebased on top of #15, it should be merged first.