### PR TITLE
Remove 'OS Independent' trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",
-    "Operating System :: OS Independent",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
We are not strictly OS independent anymore, since we access Linux
specific system functionality if it's available. The package does still
work on any system though.
