### PR TITLE
Send user's IP address with metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Send user's IP address with metrics. Used for visualization aggregate geolocation data.
+  The IP is never stored, and it is never sent to 3rd parties.
+
 ## [1.4.0] - 2022-02-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ def my_apilytics_middleware(request, get_response):
         method=request.method,
         request_size=len(request.body),
         user_agent=request.headers.get("user-agent"),
+        ip=request.headers.get("x-forwarded-for", "").split(",")[0].strip(),
     ) as sender:
         response = get_response(request)
         sender.set_response_info(

--- a/apilytics/core.py
+++ b/apilytics/core.py
@@ -33,6 +33,7 @@ class ApilyticsSender:
                 method=request.method,
                 request_size=len(request.body),
                 user_agent=request.headers.get("user-agent"),
+                ip=request.headers.get("x-forwarded-for", "").split(",")[0].strip(),
             ) as sender:
                 response = get_response(request)
                 sender.set_response_info(
@@ -56,6 +57,7 @@ class ApilyticsSender:
         query: Optional[str] = None,
         request_size: Optional[int] = None,
         user_agent: Optional[str] = None,
+        ip: Optional[str] = None,
         apilytics_integration: Optional[str] = None,
         integrated_library: Optional[str] = None,
     ) -> None:
@@ -71,6 +73,8 @@ class ApilyticsSender:
             request_size: Size of the user's HTTP request's body in bytes.
             user_agent: Value of the `User-Agent` header from the user's HTTP request.
                 An empty string and None are treated equally.
+            ip: User's IP address (used for geolocation, never stored nor sent to 3rd parties).
+                An empty string and None are treated equally.
             apilytics_integration: Name of the Apilytics integration that's calling this,
                 e.g. "apilytics-python-django". No need to pass this when calling from user code.
             integrated_library: Name and version of the integration that this is used in,
@@ -82,6 +86,7 @@ class ApilyticsSender:
         self._query = query
         self._request_size = request_size
         self._user_agent = user_agent
+        self._ip = ip
 
         self._response_size: Optional[int] = None
         self._status_code: Optional[int] = None
@@ -148,6 +153,7 @@ class ApilyticsSender:
             # Don't send empty strings.
             **({"query": self._query} if self._query else {}),
             **({"userAgent": self._user_agent} if self._user_agent else {}),
+            **({"ip": self._ip} if self._ip else {}),
             **(
                 {"statusCode": self._status_code}
                 if self._status_code is not None

--- a/apilytics/core.py
+++ b/apilytics/core.py
@@ -70,6 +70,7 @@ class ApilyticsSender:
                 An empty string and None are treated equally. Can have an optional "?" at the start.
             request_size: Size of the user's HTTP request's body in bytes.
             user_agent: Value of the `User-Agent` header from the user's HTTP request.
+                An empty string and None are treated equally.
             apilytics_integration: Name of the Apilytics integration that's calling this,
                 e.g. "apilytics-python-django". No need to pass this when calling from user code.
             integrated_library: Name and version of the integration that this is used in,

--- a/apilytics/django.py
+++ b/apilytics/django.py
@@ -49,6 +49,7 @@ class ApilyticsMiddleware:
             method=request.method or "",  # Typed as Optional, should never be None.
             request_size=int(request.META.get("CONTENT_LENGTH", 0)),
             user_agent=request.headers.get("user-agent"),
+            ip=request.headers.get("x-forwarded-for", "").split(",")[0].strip(),
             apilytics_integration="apilytics-python-django",
             integrated_library=f"django/{django.__version__}",
         ) as sender:

--- a/apilytics/fastapi.py
+++ b/apilytics/fastapi.py
@@ -57,6 +57,7 @@ class ApilyticsMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             method=request.method,
             request_size=len(await request.body()),
             user_agent=request.headers.get("user-agent"),
+            ip=request.headers.get("x-forwarded-for", "").split(",")[0].strip(),
             apilytics_integration="apilytics-python-fastapi",
             integrated_library=f"fastapi/{fastapi.__version__}",
         ) as sender:

--- a/tests/django/test_django.py
+++ b/tests/django/test_django.py
@@ -87,6 +87,26 @@ def test_middleware_should_send_user_agent(
     assert data["userAgent"] == "some agent"
 
 
+def test_middleware_should_send_ip(
+    mocked_urlopen: unittest.mock.MagicMock, client: django.test.client.Client
+) -> None:
+    response = client.get("/dummy", HTTP_X_FORWARDED_FOR="127.0.0.1")
+    assert response.status_code == 200
+
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert data["ip"] == "127.0.0.1"
+
+    response = client.get("/dummy", HTTP_X_FORWARDED_FOR="127.0.0.2,127.0.0.3")
+    assert response.status_code == 200
+
+    assert mocked_urlopen.call_count == 2
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert data["ip"] == "127.0.0.2"
+
+
 def test_middleware_should_handle_zero_request_and_response_sizes(
     mocked_urlopen: unittest.mock.MagicMock, client: django.test.client.Client
 ) -> None:

--- a/tests/fastapi/test_fastapi.py
+++ b/tests/fastapi/test_fastapi.py
@@ -94,6 +94,26 @@ def test_middleware_should_send_user_agent(
     assert data["userAgent"] == "some agent"
 
 
+def test_middleware_should_send_ip(
+    mocked_urlopen: unittest.mock.MagicMock,
+) -> None:
+    response = client.get("/dummy", headers={"X-Forwarded-For": "127.0.0.1"})
+    assert response.status_code == 200
+
+    assert mocked_urlopen.call_count == 1
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert data["ip"] == "127.0.0.1"
+
+    response = client.get("/dummy", headers={"X-Forwarded-For": "127.0.0.2,127.0.0.3"})
+    assert response.status_code == 200
+
+    assert mocked_urlopen.call_count == 2
+    __, call_kwargs = mocked_urlopen.call_args
+    data = tests.conftest.decode_request_data(call_kwargs["data"])
+    assert data["ip"] == "127.0.0.2"
+
+
 def test_middleware_should_handle_zero_request_and_response_sizes(
     mocked_urlopen: unittest.mock.MagicMock,
 ) -> None:


### PR DESCRIPTION
Used for visualization aggregate geolocation data. The IP is never
stored, and it is never sent to 3rd parties.

We read the IP from the `X-Forwarded-For` header since in production
one's backend service is most likely behind a reverse proxy of some
sort. We use the left-most value in case there are multiple IPs in it,
since that's most likely not from "our" infra and we don't have to worry
about spoofing too much because it's not used for anything security
related.

Some additional reading about getting the real IP address:
https://adam-p.ca/blog/2022/03/x-forwarded-for/