### PR TITLE
Explicitly handle closing `urllib.request.urlopen` requests

### DIFF
--- a/apilytics/core.py
+++ b/apilytics/core.py
@@ -184,7 +184,8 @@ class ApilyticsSender:
             **({"memoryTotal": memory_total} if memory_total is not None else {}),
         }
         try:
-            urllib.request.urlopen(url=request, data=json.dumps(data).encode())
+            with urllib.request.urlopen(url=request, data=json.dumps(data).encode()):
+                pass
         except urllib.error.URLError:
             pass
 


### PR DESCRIPTION
It does close `self.close()` in its `__del__` method[1], but it's better
to not just rely on the garbage collector here.

[1]: At least in CPython:
https://github.com/python/cpython/blob/cd26595232ac1b5061460d5949d5204c90287c1c/Lib/urllib/request.py#L1737
